### PR TITLE
fix: undefined pointerId onClick

### DIFF
--- a/public/editor.js
+++ b/public/editor.js
@@ -116,7 +116,7 @@ export class Editor
         {
             console.log('editor click');
 
-            this.editorDiv.releasePointerCapture(evt.pointerId);
+            if (evt.pointerId) this.editorDiv.releasePointerCapture(evt.pointerId);
             this.startMousePos = null;
 
             // If we were in the process of selecting nodes


### PR DESCRIPTION
On some Chrome versions releasepointercapture(undefined) throws a DOMexception which it was not guarded against. 