### PR TITLE
Fixed reject error message

### DIFF
--- a/server.js
+++ b/server.js
@@ -174,7 +174,7 @@ async function getTitle(projectId)
             {
                 if (err || !row)
                 {
-                    reject('user not found');
+                    reject('project not found');
                     return;
                 }
 


### PR DESCRIPTION
It looks like this is a copy/paste bug - this function is trying to find a project by ID, so 'project not found' message would fit better.