### PR TITLE
Resume the AudioContext for Safari

### DIFF
--- a/public/audioview.js
+++ b/public/audioview.js
@@ -130,6 +130,7 @@ export class AudioView
             latencyHint: 'interactive',
             sampleRate: 44100
         });
+        this.audioCtx.resume();
 
         await this.audioCtx.audioWorklet.addModule('/public/audioworklet.js');
 


### PR DESCRIPTION
This PR makes sure the `AudioContext` gets resumed which seems to be necessary in Safari.