### PR TITLE
Add SVG icons and restyle play/stop

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -32,8 +32,19 @@
             </div>
 
             <div class="top_buttons">
-                <div class="menu_button" id="btn_play">Play</div>
-                <div class="menu_button" style="display:none" id="btn_stop">Stop</div>
+                <div class="menu_button" id="btn_play">
+                    <svg width="15pt" height="15pt" viewBox="0 0 10 10">
+                        <path d="M 2.5,2 8,5 2.5,8 Z" style="fill:#FFF" />
+                    </svg>
+                    Play
+                </div>
+                <div class="menu_button" style="display:none" id="btn_stop">
+                    <svg width="15pt" height="15pt" viewBox="0 0 10 10">
+                        <rect width="2" height="6" x="2.5" y="2" style="fill:#FFF" />
+                        <rect width="2" height="6" x="5.5" y="2" style="fill:#FFF" />
+                    </svg>
+                    Stop
+                </div>
                 <div id="btn_login" style="cursor: pointer; color: #FA0; margin: 4px; padding: 4px;">[Log in]</div>
                 <div id="btn_user" style="cursor: pointer; display: none; color: #FA0; margin: 4px; padding: 4px;"></div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -33,17 +33,16 @@
 
             <div class="top_buttons">
                 <div class="menu_button" id="btn_play">
-                    <svg width="15pt" height="15pt" viewBox="0 0 10 10">
-                        <path d="M 2.5,2 8,5 2.5,8 Z" style="fill:#FFF" />
+                    <svg width="100%" height="100%" viewBox="0 0 60 25">
+                        <path d="M 4,7 15,13 4,19 Z" style="fill: #FFF" />
+                        <text x="21" y="19.5" style="font: 18 sans-serif; fill: #FFF">Play</text>
                     </svg>
-                    Play
                 </div>
                 <div class="menu_button" style="display:none" id="btn_stop">
-                    <svg width="15pt" height="15pt" viewBox="0 0 10 10">
-                        <rect width="2" height="6" x="2.5" y="2" style="fill:#FFF" />
-                        <rect width="2" height="6" x="5.5" y="2" style="fill:#FFF" />
+                    <svg width="100%" height="100%" viewBox="0 0 60 25">
+                        <rect x="4" y="7.5" width="11" height="11" style="fill: #FFF" />
+                        <text x="21" y="19.5" style="font: 18 sans-serif; fill: #FFF">Stop</text>
                     </svg>
-                    Stop
                 </div>
                 <div id="btn_login" style="cursor: pointer; color: #FA0; margin: 4px; padding: 4px;">[Log in]</div>
                 <div id="btn_user" style="cursor: pointer; display: none; color: #FA0; margin: 4px; padding: 4px;"></div>

--- a/public/main.js
+++ b/public/main.js
@@ -351,7 +351,7 @@ function startPlayback()
 
     // Hide the play button
     btnPlay.style.display = 'none';
-    btnStop.style.display = 'inline-block';
+    btnStop.style.display = 'inline-flex';
 
     // Send the play action to the model
     model.update(new Play());
@@ -365,7 +365,7 @@ function stopPlayback()
     console.log('stopping playback');
 
     // Hide the stop button
-    btnPlay.style.display = 'inline-block';
+    btnPlay.style.display = 'inline-flex';
     btnStop.style.display = 'none';
 
     // Send the stop action to the model

--- a/public/style.css
+++ b/public/style.css
@@ -80,11 +80,12 @@ div.top_buttons
 
 div.menu_button, a.menu_link:link, a.menu_link:visited
 {
-    display: inline-block;
+    display: inline-flex;
     margin: 4px;
     padding: 4px;
     color: #FFF;
     text-align: center;
+    align-items:center;
     font-size: 18;
     font-family: sans-serif;
     cursor: pointer;
@@ -121,6 +122,18 @@ code
     position: relative;
     top: 0px;
     left: 0px;
+}
+
+#btn_play, #btn_player:hover
+{
+    background-color: #080;
+    width: 45pt;
+}
+
+#btn_stop, #btn_stop:hover
+{
+    background-color: #F00;
+    width: 45pt;
 }
 
 #graph_div


### PR DESCRIPTION
This PR attempts to resolve #62, adding SVG icons to the play/stop button and setting them to an unchanging red/green colour.

Some decisions:
 - Icon SVG is inline.
 - To center the icon with the text, buttons are now flex contains with `align-items:center;`
 - The pure green `#0F0` is difficult to read, failing WCAG contrast ratio requirements. I've lowered it to a darker shade of green that passes. As for the red, I've left that as is for consistency with the red link buttons.
 - The icons are identically sized, but the non-monospace font caused the button to resize when clicked. I've 'fixed' this by setting a constant button width of `45pt`

Happy to revise the PR with any feedback. 🙂 

![updated-play-stop](https://user-images.githubusercontent.com/8501694/155953892-0180f15f-10fc-431e-be1e-63ad0653b1a3.gif)
