### PR TITLE
Bugfix/90 prevent graph cycles

### DIFF
--- a/public/compiler.js
+++ b/public/compiler.js
@@ -185,6 +185,24 @@ function topoSort(graph)
 }
 
 /**
+ * Detect cycles in a graph of nodes
+ */
+export function detectCycles(graph)
+{
+    try
+    {
+        topoSort(splitNodes(graph));
+        // A graph sorted with no issues has no cycle
+        return false;
+    }
+    catch (err)
+    {
+        // The only error thrown from topoSort is the SyntaxError, indicating a cycle
+        return true;
+    }
+}
+
+/**
  * Compile a sound-generating function from a graph of nodes
  */
 export function compile(graph)

--- a/public/editor.js
+++ b/public/editor.js
@@ -1,4 +1,5 @@
 import { assert, anyInputActive, makeSvg, setSvg, getBrightColor } from './utils.js';
+import { detectCycles } from './compiler.js';
 import { Dialog } from './dialog.js';
 import { NODE_SCHEMA } from './model.js';
 import * as model from './model.js';
@@ -157,6 +158,18 @@ export class Editor
 
         // Initialize the editor size to fill the window
         this.resize();
+    }
+
+    detectCycles(action)
+    {
+        // Slightly wasteful duplication allows us to avoid polluting the model's state before we've finished detection
+        let clone = new Model();
+        clone.deserialize(this.model.serialize());
+
+        // Simulate updating the model with the ConnectNodes action
+        action.update(clone);
+
+        return detectCycles(clone.state);
     }
 
     // Update the GUI view
@@ -549,6 +562,13 @@ export class Editor
         }
     }
 
+    createCycleDialog()
+    {
+        var dialog = new Dialog('Cycle in Component Graph');
+
+        dialog.appendChild(document.createTextNode("Your connection has been prevented, as it would create a cycle (or infinite loop) in the graph."));
+    }
+
     // Start dragging/moving nodes
     startDrag(nodeId, mousePos)
     {
@@ -921,6 +941,33 @@ class UINode
     }
 
     /**
+     * Generate model.ConnectNodes instance
+     */
+    generateConnectAction(side, portIdx)
+    {
+        let editor = this.editor;
+
+        if (side == 'dst')
+        {
+            return new model.ConnectNodes(
+                editor.edge.srcNode.nodeId,
+                editor.edge.srcPort,
+                this.nodeId,
+                portIdx
+            );
+        }
+        else
+        {
+            return new model.ConnectNodes(
+                this.nodeId,
+                portIdx,
+                editor.edge.dstNode.nodeId,
+                editor.edge.dstPort
+            );
+        }
+    }
+
+    /**
      * Setup DOM elements for this node
      */
     genNodeDOM(state)
@@ -1070,25 +1117,15 @@ class UINode
             {
                 return;
             }
+            
+            let connectAction = this.generateConnectAction(side, portIdx);
 
-            if (side == 'dst')
-            {
-                editor.model.update(new model.ConnectNodes(
-                    editor.edge.srcNode.nodeId,
-                    editor.edge.srcPort,
-                    this.nodeId,
-                    portIdx
-                ));
+            if (editor.detectCycles(connectAction)) {
+                editor.createCycleDialog();
+                return;
             }
-            else
-            {
-                editor.model.update(new model.ConnectNodes(
-                    this.nodeId,
-                    portIdx,
-                    editor.edge.dstNode.nodeId,
-                    editor.edge.dstPort
-                ));
-            }
+
+            editor.model.update(connectAction);
 
             // Done connecting
             editor.edge = null;


### PR DESCRIPTION
This PR resolves #90. A minimal change in compiler.js exposes a new detectCycles function, which is leveraged in editor.js for detection and prevention. Additionally, a new dialog is spawned when a cycle is prevented, and while I have endeavored to imitate the style of the repository, I made a stylistic choice to omit text centering in the new dialog box (though this can of course be added).

Comments, questions, and feedback are welcomed.