### PR TITLE
Bugfix/90 prevent graph cycles (Redux)

### DIFF
--- a/public/compiler.js
+++ b/public/compiler.js
@@ -185,6 +185,23 @@ function topoSort(graph)
 }
 
 /**
+ * Detect cycles in a graph of nodes
+ */
+export function detectCycles(graph)
+{
+    try
+    {
+        topoSort(splitNodes(graph));
+        // A graph sorted with no issues has no cycle
+        return false;
+    }
+    catch (err)
+    {
+        // The only error thrown from topoSort is the SyntaxError, indicating a cycle
+        return true;
+    }
+}/**
+
  * Compile a sound-generating function from a graph of nodes
  */
 export function compile(graph)

--- a/public/editor.js
+++ b/public/editor.js
@@ -1,5 +1,5 @@
 import { assert, anyInputActive, makeSvg, setSvg, getBrightColor } from './utils.js';
-import { Dialog } from './dialog.js';
+import { Dialog, errorDialog } from './dialog.js';
 import { NODE_SCHEMA } from './model.js';
 import * as model from './model.js';
 import * as music from './music.js';
@@ -547,13 +547,6 @@ export class Editor
 
             dialog.appendChild(subDiv);
         }
-    }
-
-    createCycleDialog()
-    {
-        var dialog = new Dialog('Cycle in Component Graph');
-
-        dialog.appendChild(document.createTextNode("Your connection has been prevented, as it would create a cycle (or infinite loop) in the graph."));
     }
 
     // Start dragging/moving nodes
@@ -1106,9 +1099,9 @@ class UINode
             }
 
             let connectAction = this.generateConnectAction(side, portIdx);
-            
+
             if (editor.model.detectCycles(connectAction)) {
-                editor.createCycleDialog();
+                errorDialog('This connection would create a cycle in the node graph.');
                 return;
             }
 

--- a/public/model.js
+++ b/public/model.js
@@ -1,4 +1,5 @@
 import { assert, isInt, isPosInt, treeCopy, treeEq, isString, isObject } from './utils.js';
+import { detectCycles } from './compiler.js';
 import * as music from './music.js';
 
 // Maximum number of undo steps we support
@@ -2020,6 +2021,18 @@ export class Model
     addView(view)
     {
         this.views.push(view);
+    }
+
+    detectCycles(action)
+    {
+        // Slightly wasteful duplication allows us to avoid polluting the model's state before we've finished detection
+        let clone = new Model();
+        clone.deserialize(this.serialize());
+
+        // Simulate updating the model with the ConnectNodes action
+        action.update(clone);
+
+        return detectCycles(clone.state);
     }
 
     // Reinitialize the state for a brand new project


### PR DESCRIPTION
Take 2 fix for #90. detectCycles logic exported from compiler.js is now leveraged by model.js to pre-check connection actions, and editor.js responsibility is reduced to invocation (and display of the notification to the user). Cycle detection has been tested with cycles between 2 nodes, 3+ nodes, and a subset of nodes forming a cycle not otherwise connected to other nodes in the editor.

Another future improvement could be to allow checking a box in the dialog, in case the user would prefer to simply be prevented without notification in the future.